### PR TITLE
Feature: Set Parmetis option from lua.

### DIFF
--- a/scripts/util/load_balancing_util_2.lua
+++ b/scripts/util/load_balancing_util_2.lua
@@ -1,5 +1,5 @@
 -- Copyright (c) 2015:  G-CSC, Goethe University Frankfurt
--- Author: Sebastian Reiter
+-- Author: Sebastian Reiter, Jan Friebertshäuser
 -- 
 -- This file is part of UG4.
 -- 

--- a/scripts/util/load_balancing_util_2.lua
+++ b/scripts/util/load_balancing_util_2.lua
@@ -98,6 +98,7 @@ util.balancer.defaults =
 		{
 			balanceWeights = nil,
 			communicationWeights = nil,
+			options = nil,
 			childWeight		= 2,
 			siblingWeight	= 2,
 			itrFactor		= 1000,
@@ -261,6 +262,15 @@ function util.balancer.CreatePartitioner(dom, partitionerDesc)
 		end
 		if util.tableDesc.IsPreset(desc.communicationWeights) then
 			partitioner:set_communication_weights(desc.communicationWeights)
+		end
+		-- create parmetis options if none were specified.
+		if desc.options ~= nil then
+			partitioner:set_options(desc.options)
+		elseif defaults.options ~= nil then
+			partitioner:set_options(default.options)
+	  	else
+	   		options = ParmetisOptions()
+			partitioner:set_options(options)
 		end
 	else
 		print("ERROR: Unknown partitioner specified in balancer.CreateLoadBalancer: " .. name)


### PR DESCRIPTION
Adds the possibility to add parmetis options from the lua scripts.
Options can be set by name as described in the METIS Manual.
See commit #62b9d24431fea0f1778954f29b58b3cd6fb023a7 at gitolite@quadruped.gcsc.uni-frankfurt.de:plugin_Parmetis.git for the implementation of the option setter functions.