### PR TITLE
enabling use of queue parameter in hawk

### DIFF
--- a/scripts/shell/schedulers/hawk
+++ b/scripts/shell/schedulers/hawk
@@ -39,7 +39,7 @@ function UJS_Submit
 	if [ -z "$queue" ]; then
 		qsubqueue=""
 	else
-		qsubqueue="-queue $queue"
+		qsubqueue="-q $queue"
 	fi			
 	
 	if [ $exclusive == true ]; then


### PR DESCRIPTION
The parameter -queue is not identified by qsub, and an error is returned which prevents scheduling if the queue must be specified in the bash script with ugsubmit. I did a simple correction in the scheduler file. 