### PR TITLE
add github workflow to trigger a workflow dispatch event for generation of doxygen documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch for Documentation
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.UG4_DOCS }}
+          repository: nordegraf/ug4_docs
+          event-type: trigger-doxygen


### PR DESCRIPTION
This PR adds a GitHub Workflow for triggering a workflow dispatch event when pushing to the master branch. This event is used by the docs repository to automatically generate and publish the documentation of UG4 and its plugins.

See UG4/docs#1 for reference