### PR TITLE
add member function to get reference to value vector of a sparse matrix

### DIFF
--- a/ugbase/lib_algebra/cpu_algebra/sparsematrix.h
+++ b/ugbase/lib_algebra/cpu_algebra/sparsematrix.h
@@ -639,6 +639,17 @@ public:
 		nnz = total_num_connections();
 	}
 
+	/**
+	 * assigns a reference to the values vector to argument vector
+	 * 
+	 * \param argValues vector to be assigned
+	 */
+	void get_values(std::vector<value_type> &argValues) const
+	{
+		defragment();
+		argValues = values;
+	}
+
 
 public:
 	// output functions


### PR DESCRIPTION
adds a function to the sparse matrix class to get a reference to the values vector of the crs matrix.

needed to compare results of regression tests