### PR TITLE
Remove relative path in `jsonPath`

### DIFF
--- a/scripts/util/json_util.lua
+++ b/scripts/util/json_util.lua
@@ -3,7 +3,7 @@ util = util or {}
 -- If UG_JSON is active, load third party module as util.json
 if IsDefinedUG_JSON() then
 
-  local jsonPath = ug_get_apps_path().."/../externals/JSONForUG4/json-lua/"
+  local jsonPath = ug_get_root_path().."externals/JSONForUG4/json-lua/"
   package.path = package.path..";".. jsonPath.."?.lua"
   util.json = require("json")
   


### PR DESCRIPTION
Switched from `ug_get_apps_path()` to `ug_get_root_path()` to remove the relative path to the json.lua file. On various Linux systems the file could not be found before.