### PR TITLE
fix typo in autodiff cmake

### DIFF
--- a/cmake/ug/autodiff.cmake
+++ b/cmake/ug/autodiff.cmake
@@ -40,7 +40,7 @@ if(USE_AUTODIFF)
 	IF (EXTERNAL_AUTODIFF) # Automatic
     	FIND_PACKAGE(autodiff CONFIG REQUIRED)
 	else (EXTERNAL_AUTODIFF)# Builtin
-		SET(autodiff_DIR ${UG_ROOT_CMAKE_PATH}/../../externals/AutoDiffForUG4/autodiff)
+		SET(autodiff_DIR ${UG_ROOT_CMAKE_PATH}/../../externals/AutodiffForUG4/autodiff)
    	ENDIF(EXTERNAL_AUTODIFF)
    	   	
    	MESSAGE(STATUS "Info: Using Autodiff from ${autodiff_DIR}")


### PR DESCRIPTION
fixes a typo in the cmake config for autodiff. Before the git submodule call failed. Now it finds the correct path