### PR TITLE
Update dgegv_ to dggev_

### DIFF
--- a/ugbase/lib_algebra/small_algebra/lapack/lapack_interface.h
+++ b/ugbase/lib_algebra/small_algebra/lapack/lapack_interface.h
@@ -1,20 +1,20 @@
 /*
  * Copyright (c) 2010-2014:  G-CSC, Goethe University Frankfurt
  * Author: Martin Rupp
- * 
+ *
  * This file is part of UG4.
- * 
+ *
  * UG4 is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License version 3 (as published by the
  * Free Software Foundation) with the following additional attribution
  * requirements (according to LGPL/GPL v3 §7):
- * 
+ *
  * (1) The following notice must be displayed in the Appropriate Legal Notices
  * of covered and combined works: "Based on UG4 (www.ug4.org/license)".
- * 
+ *
  * (2) The following notice must be displayed at a prominent place in the
  * terminal output of covered works: "Based on UG4 (www.ug4.org/license)".
- * 
+ *
  * (3) The following bibliography is recommended for citation and must be
  * preserved in all covered files:
  * "Reiter, S., Vogel, A., Heppner, I., Rupp, M., and Wittum, G. A massively
@@ -23,7 +23,7 @@
  * "Vogel, A., Reiter, S., Rupp, M., Nägel, A., and Wittum, G. UG4 -- a novel
  *   flexible software system for simulating pde based models on high performance
  *   computers. Computing and visualization in science 16, 4 (2013), 165-179"
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
@@ -58,7 +58,7 @@
 namespace ug{
 
 extern "C" // solve generalized eigenvalue system
-	void dgegv_(char *cCalcLeftEV, char *cCalcRightEV, lapack_int *n,
+	void dggev_(char *cCalcLeftEV, char *cCalcRightEV, lapack_int *n,
 			lapack_double *pColMajorMatrixA, lapack_int *lda, lapack_double *pColMajorMatrixB,
 			lapack_int *ldb, lapack_double *alphar,	lapack_double *alphai, lapack_double *beta,
 			lapack_double *vl, lapack_int *ldvl, lapack_double *vr, lapack_int *ldvr, lapack_double *pWork,
@@ -72,7 +72,7 @@ inline lapack_int gegv(bool calcLeftEV, bool calcRightEV, lapack_int n,
 	char jobvl = calcLeftEV ? 'V' : 'N';
 	char jobvr = calcRightEV ? 'V' : 'N';
 	lapack_int info=0;
-	dgegv_(&jobvl, &jobvr, &n, pColMajorMatrixA, &leading_dim_a, pColMajorMatrixB, &leading_dim_b, alphar, alphai, beta, vl, &leading_dim_vl, vr, &leading_dim_vr, work, &worksize, &info);
+	dggev_(&jobvl, &jobvr, &n, pColMajorMatrixA, &leading_dim_a, pColMajorMatrixB, &leading_dim_b, alphar, alphai, beta, vl, &leading_dim_vl, vr, &leading_dim_vr, work, &worksize, &info);
 	return info;
 }
 


### PR DESCRIPTION
Lapack's dgegv_ has been deprecated for quite some time now and has been removed in Lapack 3.12, which was released in January.

The dgegv kernel has been replaced by dggev, which has the same signature and does the same as dgegv. 

I simply changed the corresponding function names in the lapack interface. Everything else can stay the same. 
