### PR TITLE
Feature/reduce boost

### DIFF
--- a/ugbase/bindings/vrl/user_data.cpp
+++ b/ugbase/bindings/vrl/user_data.cpp
@@ -42,7 +42,7 @@
 #include "threading.h"
 #include <iostream>
 #include <sstream>
-#include <boost/function.hpp>
+// #include <functional> // std::function
 #include <jni.h>
 #include "lib_disc/spatial_disc/user_data/user_data.h"
 #include "lib_disc/spatial_disc/user_data/std_glob_pos_data.h"

--- a/ugbase/boost_undo.md
+++ b/ugbase/boost_undo.md
@@ -24,13 +24,25 @@ o: Done (obsolet)
 m: Neue Header (MPL).
 
 
+
+
 Weitere Dateiabhängigkeiten von <boost/*>
 
 - ugcore/ugbase/bridge/misc_bridges/test_bridge.cpp: <boost/bind.hpp>
-- ugcore/ugbase/common/util/message_hub.h: <boost/function_equal.hpp>, <boost/bind.hpp>
-- ugcore/ugbase/common/util/factory.h: <boost/static_assert.hpp>, <boost/mpl/for_each.hpp>, <boost/mpl/vector.hpp>, <boost/type_traits/is_base_of.hpp>
-- ugcore/ugbase/common/util/archivar.h: <boost/static_assert.hpp>, <boost/mpl/for_each.hpp>, <boost/type_traits/is_base_of.hpp>
-- ugcore/ugbase/common/util/field.h: <boost/serialization/split_member.hpp>
+- ugcore/ugbase/common/util/message_hub.h: <boost/bind.hpp>
+- ugcore/ugbase/common/util/factory.h: 
+    <boost/mpl/for_each.hpp>, 
+    <boost/mpl/vector.hpp>,
+
+ f: <boost/static_assert.hpp>
+ f: <boost/type_traits/is_base_of.hpp>
+- ugcore/ugbase/common/util/archivar.h: 
+ <boost/mpl/for_each.hpp>, 
+
+ f: <boost/static_assert.hpp>,
+ f: <boost/type_traits/is_base_of.hpp>
+- ugcore/ugbase/common/util/field.h: 
+<boost/serialization/split_member.hpp>
 - ugcore/ugbase/common/util/base64_file_writer.cpp: <boost/archive/iterators/transform_width.hpp>, <boost/archive/iterators/base64_from_binary.hpp>, <boost/archive/iterators/ostream_iterator.hpp>
 - ugcore/ugbase/common/util/smart_pointer.h: <boost/pointee.hpp>
 - ugcore/ugbase/common/util/bucket_sorter.hpp: (auskommentiert) <boost/limits.hpp>
@@ -69,3 +81,36 @@ Weitere Dateiabhängigkeiten von <boost/*>
 - ugcore/ugbase/lib_disc/ordering_strategies/algorithms/directional_ordering.cpp: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/cuthill_mckee_ordering.hpp>
 
 Hinweis: Die Liste basiert auf einer Quelltextsuche nach "#include <boost/...>" unter `ugcore/ugbase`. Manche Einträge sind auskommentiert oder mehrfach vorhanden (z.B. Header + generierte Build-Dependency-Dateien). 
+
+
+## Migrationsvorschlag — Reihenfolge (priorisiert, kurz)
+
+1. Funktionale-APIs (niedriges Risiko): Ersetze boost::function / boost::bind durch std::function, std::bind oder besser: C++11-Lambdas. Dateien zuerst prüfen: alle Einträge in boost_undo.md, z.B. user_data.cpp, ugcore/ugbase/lib_grid/.... Aufwand: niedrig. Test: kompilieren + Unittests.
+
+2. Smart-Pointer (niedriges Risiko): Ersetze boost::shared_ptr, boost::weak_ptr, boost::make_shared durch std::shared_ptr, std::weak_ptr, std::make_shared. Aufwand: niedrig–mittel (API-Suche/typedefs). Test: kompilieren.
+
+3. Type Traits & Metaprogramming (niedriges bis mittleres Risiko): Migriere boost::is_base_of, boost::enable_if, boost::type_traits → <type_traits> (std::is_base_of, std::enable_if_t/std::enable_if). Für MPL- (Boost.MPL) heavy uses: erst analysieren; viele MPL-Patterns bleiben (siehe bridge/*, lib_disc/*). Aufwand: mittel. Test: kompilieren.
+
+4. String/Conversion (niedriges Risiko): Ersetze boost::lexical_cast durch std::to_string, std::stoi/std::stod oder std::stringstream wo passend. Aufwand: niedrig.
+
+5. Threading (mittleres Risiko): Ersetze boost::thread, boost::mutex, boost::condition_variable durch std::thread, std::mutex, std::condition_variable. Achte auf thread-API-Differenzen (interrupts, join/detach). Aufwand: mittel. Test: Laufzeit- und race-tests.
+
+6. Iterators / Algorithmic helpers (mittel): Manche Boost-Iteratoren/Adaptoren (z.B. filter_iterator, counting_iterator) fehlen in STL — entweder implementieren kleine wrappers oder verwenden einfache loops/lambdas. Aufwand: mittel.
+
+7. Small utilities (niedrig): Ersetze boost::pointee, boost::function_equal etc. durch kleine helper-Funktionen / Standard-Pattern. Aufwand: niedrig.
+
+8. I/O / Archiving / Serialization / Graph / MPL (hohes Risiko, defer):
+
+Boost.Serialization / Boost.Archive (boost/archive/...) hat keine direkte C++11-Ersatzlösung — entweder behalten oder auf Alternativen ( cereal, protobuf ) migrieren (großer Aufwand).
+Boost.Graph, Boost.MPL, Boost.Geometry sind größere Subsysteme; nur migrieren wenn zwingend (hoher Aufwand / Design-Entscheidung).
+Empfehlung: diese Schritte ans Ende setzen und erst planen, wenn kleinere Ersetzungen abgeschlossen und Tests stabil sind.
+9. Build & CI (parallel, kontinuierlich): Nach jeder Gruppen-Migration: Branch erstellen, CMake anpassen (schrittweise Boost-Componenten entfernen), komplette Build + Tests laufen lassen. Dokumentation der Änderungen in boost_undo.md/CHANGES.
+
+10. Final: Aufräumen & Deduplizieren: Entferne jetzt unnötige #include <boost/...>-Zeilen, dedupliziere boost_undo.md-Fundstellen, committen und ggf. PR.
+
+## Kurz-Checklist pro Migrationsschritt:
+
+a. Grep alle Vorkommen (Scope: ugbase / Dateien in boost_undo.md).
+b. Ändern mit kleinen, isolierten Kommits.
+c. Kompilieren + Tests ausführen.
+d. CI grün → weitermachen.

--- a/ugbase/boost_undo.md
+++ b/ugbase/boost_undo.md
@@ -1,28 +1,33 @@
-Dateien in `ugcore/ugbase`, die <boost/function.hpp> einbinden
+# Übersicht
+In folgenden Dateien in `ugcore/ugbase`, wurden die Abhängigkeiten von <boost/function.hpp> entfernt:
 
-- ugcore/ugbase/bindings/vrl/user_data.cpp
-- ugcore/ugbase/lib_grid/grid/grid.h
-- ugcore/ugbase/lib_grid/parallelization/parallelization_util.h
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
-- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
-- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
-- ugcore/ugbase/registry/registry.h
-- ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h
-- ugcore/ugbase/lib_disc/function_spaces/integrate.h
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
-- ugcore/ugbase/common/util/message_hub.h
-- ugcore/ugbase/pcl/pcl_layout_tests.h
+## Dateiliste
+o ugcore/ugbase/bindings/vrl/user_data.cpp
+f ugcore/ugbase/lib_grid/grid/grid.h
+f ugcore/ugbase/lib_grid/parallelization/parallelization_util.h
+o ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
+o ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
+o ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
+o ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
+ ougcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
+f ugcore/ugbase/registry/registry.h
+o ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h
+o ugcore/ugbase/lib_disc/function_spaces/integrate.h
+m ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
+o ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
+f ugcore/ugbase/common/util/message_hub.h
+f ugcore/ugbase/pcl/pcl_layout_tests.h
+
+## Legende
+f: Done (fixed)
+o: Done (obsolet)
+m: Neue Header (MPL).
+
 
 Weitere Dateiabhängigkeiten von <boost/*>
 
-- ugcore/ugbase/bindings/vrl/user_data.cpp: <boost/function.hpp>
-- ugcore/ugbase/bridge/disc_bridges/user_data_bridge.cpp: <boost/function.hpp>
-- ugcore/ugbase/bridge/disc_bridges/user_data_bridge.cpp.orig: <boost/function.hpp>
 - ugcore/ugbase/bridge/misc_bridges/test_bridge.cpp: <boost/bind.hpp>
-- ugcore/ugbase/common/util/message_hub.h: <boost/function.hpp>, <boost/function_equal.hpp>, <boost/bind.hpp>
+- ugcore/ugbase/common/util/message_hub.h: <boost/function_equal.hpp>, <boost/bind.hpp>
 - ugcore/ugbase/common/util/factory.h: <boost/static_assert.hpp>, <boost/mpl/for_each.hpp>, <boost/mpl/vector.hpp>, <boost/type_traits/is_base_of.hpp>
 - ugcore/ugbase/common/util/archivar.h: <boost/static_assert.hpp>, <boost/mpl/for_each.hpp>, <boost/type_traits/is_base_of.hpp>
 - ugcore/ugbase/common/util/field.h: <boost/serialization/split_member.hpp>
@@ -31,19 +36,13 @@ Weitere Dateiabhängigkeiten von <boost/*>
 - ugcore/ugbase/common/util/bucket_sorter.hpp: (auskommentiert) <boost/limits.hpp>
 - ugcore/ugbase/common/util/end_boost_list.h: <boost/mpl/list.hpp>
 - ugcore/ugbase/common/boost_serialization.h: <boost/serialization/access.hpp>, <boost/serialization/export.hpp>, <boost/serialization/level.hpp>, <boost/serialization/nvp.hpp>, <boost/serialization/version.hpp>
-- ugcore/ugbase/lib_grid/grid/grid.h: <boost/function.hpp>
 - ugcore/ugbase/lib_grid/grid_objects/grid_dim_traits.h: <boost/mpl/list.hpp>
-- ugcore/ugbase/lib_grid/parallelization/parallelization_util.h: <boost/function.hpp>
 - ugcore/ugbase/lib_grid/refinement/projectors/projectors.h: <boost/mpl/pair.hpp>, <boost/mpl/string.hpp>, <boost/mpl/vector.hpp>
 - ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.h: <boost/serialization/split_member.hpp>
 - ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.cpp: <boost/lexical_cast.hpp>
 - ugcore/ugbase/lib_grid/file_io/file_io_ugx.cpp: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
 - ugcore/ugbase/lib_grid/file_io/file_io_lgb.cpp: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
 - ugcore/ugbase/lib_grid/file_io/file_io_swc.cpp: <boost/lexical_cast.hpp>
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp: <boost/function.hpp>
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp: <boost/function.hpp>
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp: <boost/function.hpp>
-- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h/.cpp: <boost/function.hpp>
 - ugcore/ugbase/lib_grid/algorithms/serialization.cpp: (auskommentiert) <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
 - ugcore/ugbase/lib_grid/tools/periodic_boundary_manager_impl.hpp: <boost/mpl/map.hpp>, <boost/mpl/at.hpp>
 - ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/topological_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>
@@ -59,11 +58,7 @@ Weitere Dateiabhängigkeiten von <boost/*>
 - ugcore/ugbase/lib_algebra/operator/interface/constrained_linear_iterator.h: <boost/core/enable_if.hpp>, <boost/type_traits/is_base_of.hpp>
 - ugcore/ugbase/lib_algebra/common/matrixio/matrix_io_mtx.h: <boost/algorithm/string.hpp>, <boost/lexical_cast.hpp>
 - ugcore/ugbase/registry/class.h: <boost/type_traits.hpp>, <boost/optional.hpp>
-- ugcore/ugbase/registry/registry.h: <boost/function.hpp>, <boost/type_traits.hpp>
-- ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h: <boost/function.hpp>
-- ugcore/ugbase/lib_disc/function_spaces/integrate.h: <boost/function.hpp>
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h: <boost/function.hpp>
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h: <boost/function.hpp>
+- ugcore/ugbase/registry/registry.h:  <boost/type_traits.hpp>
 - ugcore/ugbase/lib_disc/spatial_disc/elem_disc/err_est_data.h: <boost/mpl/for_each.hpp>
 - ugcore/ugbase/lib_disc/spatial_disc/disc_util/conv_shape.h: <boost/mpl/range_c.hpp>, <boost/mpl/for_each.hpp>
 - ugcore/ugbase/lib_disc/domain_impl.h: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
@@ -73,22 +68,4 @@ Weitere Dateiabhängigkeiten von <boost/*>
 - ugcore/ugbase/lib_disc/ordering_strategies/algorithms/riverorder.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>
 - ugcore/ugbase/lib_disc/ordering_strategies/algorithms/directional_ordering.cpp: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/cuthill_mckee_ordering.hpp>
 
-Hinweis: Die Liste basiert auf einer Quelltextsuche nach "#include <boost/...>" unter `ugcore/ugbase`. Manche Einträge sind auskommentiert oder mehrfach vorhanden (z.B. Header + generierte Build-Dependency-Dateien). Wenn du möchtest, kann ich die Liste deduplizieren, vollständig als CSV/JSON exportieren oder fehlende Treffer nachprüfen.
-
-Dateien in `ugcore/ugbase`, die <boost/function.hpp> einbinden
-
-- ugcore/ugbase/bindings/vrl/user_data.cpp
-- ugcore/ugbase/lib_grid/grid/grid.h
-- ugcore/ugbase/lib_grid/parallelization/parallelization_util.h
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
-- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
-- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
-- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
-- ugcore/ugbase/registry/registry.h
-- ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h
-- ugcore/ugbase/lib_disc/function_spaces/integrate.h
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
-- ugcore/ugbase/common/util/message_hub.h
-- ugcore/ugbase/pcl/pcl_layout_tests.h
+Hinweis: Die Liste basiert auf einer Quelltextsuche nach "#include <boost/...>" unter `ugcore/ugbase`. Manche Einträge sind auskommentiert oder mehrfach vorhanden (z.B. Header + generierte Build-Dependency-Dateien). 

--- a/ugbase/boost_undo.md
+++ b/ugbase/boost_undo.md
@@ -1,0 +1,94 @@
+Dateien in `ugcore/ugbase`, die <boost/function.hpp> einbinden
+
+- ugcore/ugbase/bindings/vrl/user_data.cpp
+- ugcore/ugbase/lib_grid/grid/grid.h
+- ugcore/ugbase/lib_grid/parallelization/parallelization_util.h
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
+- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
+- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
+- ugcore/ugbase/registry/registry.h
+- ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h
+- ugcore/ugbase/lib_disc/function_spaces/integrate.h
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
+- ugcore/ugbase/common/util/message_hub.h
+- ugcore/ugbase/pcl/pcl_layout_tests.h
+
+Weitere Dateiabhängigkeiten von <boost/*>
+
+- ugcore/ugbase/bindings/vrl/user_data.cpp: <boost/function.hpp>
+- ugcore/ugbase/bridge/disc_bridges/user_data_bridge.cpp: <boost/function.hpp>
+- ugcore/ugbase/bridge/disc_bridges/user_data_bridge.cpp.orig: <boost/function.hpp>
+- ugcore/ugbase/bridge/misc_bridges/test_bridge.cpp: <boost/bind.hpp>
+- ugcore/ugbase/common/util/message_hub.h: <boost/function.hpp>, <boost/function_equal.hpp>, <boost/bind.hpp>
+- ugcore/ugbase/common/util/factory.h: <boost/static_assert.hpp>, <boost/mpl/for_each.hpp>, <boost/mpl/vector.hpp>, <boost/type_traits/is_base_of.hpp>
+- ugcore/ugbase/common/util/archivar.h: <boost/static_assert.hpp>, <boost/mpl/for_each.hpp>, <boost/type_traits/is_base_of.hpp>
+- ugcore/ugbase/common/util/field.h: <boost/serialization/split_member.hpp>
+- ugcore/ugbase/common/util/base64_file_writer.cpp: <boost/archive/iterators/transform_width.hpp>, <boost/archive/iterators/base64_from_binary.hpp>, <boost/archive/iterators/ostream_iterator.hpp>
+- ugcore/ugbase/common/util/smart_pointer.h: <boost/pointee.hpp>
+- ugcore/ugbase/common/util/bucket_sorter.hpp: (auskommentiert) <boost/limits.hpp>
+- ugcore/ugbase/common/util/end_boost_list.h: <boost/mpl/list.hpp>
+- ugcore/ugbase/common/boost_serialization.h: <boost/serialization/access.hpp>, <boost/serialization/export.hpp>, <boost/serialization/level.hpp>, <boost/serialization/nvp.hpp>, <boost/serialization/version.hpp>
+- ugcore/ugbase/lib_grid/grid/grid.h: <boost/function.hpp>
+- ugcore/ugbase/lib_grid/grid_objects/grid_dim_traits.h: <boost/mpl/list.hpp>
+- ugcore/ugbase/lib_grid/parallelization/parallelization_util.h: <boost/function.hpp>
+- ugcore/ugbase/lib_grid/refinement/projectors/projectors.h: <boost/mpl/pair.hpp>, <boost/mpl/string.hpp>, <boost/mpl/vector.hpp>
+- ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.h: <boost/serialization/split_member.hpp>
+- ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.cpp: <boost/lexical_cast.hpp>
+- ugcore/ugbase/lib_grid/file_io/file_io_ugx.cpp: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_grid/file_io/file_io_lgb.cpp: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_grid/file_io/file_io_swc.cpp: <boost/lexical_cast.hpp>
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp: <boost/function.hpp>
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp: <boost/function.hpp>
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp: <boost/function.hpp>
+- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h/.cpp: <boost/function.hpp>
+- ugcore/ugbase/lib_grid/algorithms/serialization.cpp: (auskommentiert) <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_grid/tools/periodic_boundary_manager_impl.hpp: <boost/mpl/map.hpp>, <boost/mpl/at.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/topological_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/SCC_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/graph_utility.hpp>, <boost/graph/strong_components.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/boost_minimum_degree_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/minimum_degree_ordering.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/boost_cuthill_mckee_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/cuthill_mckee_ordering.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/util.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/undirected_boost.h: <boost/iterator/counting_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/boost_util.h: <boost/iterator/filter_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/parallel_matrix.h: <boost/iterator/filter_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/sparsematrix_boost.h: <boost/graph/properties.hpp>, <boost/iterator/counting_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/undirected.h: <boost/geometry/iterators/concatenate_iterator.hpp>, <boost/graph/adjacency_list.hpp>
+- ugcore/ugbase/lib_algebra/operator/interface/constrained_linear_iterator.h: <boost/core/enable_if.hpp>, <boost/type_traits/is_base_of.hpp>
+- ugcore/ugbase/lib_algebra/common/matrixio/matrix_io_mtx.h: <boost/algorithm/string.hpp>, <boost/lexical_cast.hpp>
+- ugcore/ugbase/registry/class.h: <boost/type_traits.hpp>, <boost/optional.hpp>
+- ugcore/ugbase/registry/registry.h: <boost/function.hpp>, <boost/type_traits.hpp>
+- ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h: <boost/function.hpp>
+- ugcore/ugbase/lib_disc/function_spaces/integrate.h: <boost/function.hpp>
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h: <boost/function.hpp>
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h: <boost/function.hpp>
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/err_est_data.h: <boost/mpl/for_each.hpp>
+- ugcore/ugbase/lib_disc/spatial_disc/disc_util/conv_shape.h: <boost/mpl/range_c.hpp>, <boost/mpl/for_each.hpp>
+- ugcore/ugbase/lib_disc/domain_impl.h: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_disc/reference_element/element_list_traits.h: <boost/mpl/transform_view.hpp>, <boost/mpl/fold.hpp>, <boost/mpl/min_max.hpp>
+- ugcore/ugbase/bridge/util_algebra_dependent.h: <boost/mpl/if.hpp>, <boost/mpl/list.hpp>, <boost/mpl/empty.hpp>, <boost/mpl/front.hpp>, <boost/mpl/pop_front.hpp>
+- ugcore/ugbase/bridge/util_domain_dependent.h: <boost/mpl/if.hpp>, <boost/mpl/list.hpp>, <boost/mpl/empty.hpp>, <boost/mpl/front.hpp>, <boost/mpl/pop_front.hpp>
+- ugcore/ugbase/lib_disc/ordering_strategies/algorithms/riverorder.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>
+- ugcore/ugbase/lib_disc/ordering_strategies/algorithms/directional_ordering.cpp: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/cuthill_mckee_ordering.hpp>
+
+Hinweis: Die Liste basiert auf einer Quelltextsuche nach "#include <boost/...>" unter `ugcore/ugbase`. Manche Einträge sind auskommentiert oder mehrfach vorhanden (z.B. Header + generierte Build-Dependency-Dateien). Wenn du möchtest, kann ich die Liste deduplizieren, vollständig als CSV/JSON exportieren oder fehlende Treffer nachprüfen.
+
+Dateien in `ugcore/ugbase`, die <boost/function.hpp> einbinden
+
+- ugcore/ugbase/bindings/vrl/user_data.cpp
+- ugcore/ugbase/lib_grid/grid/grid.h
+- ugcore/ugbase/lib_grid/parallelization/parallelization_util.h
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
+- ugcore/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
+- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
+- ugcore/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
+- ugcore/ugbase/registry/registry.h
+- ugcore/ugbase/lib_disc/function_spaces/grid_function_util.h
+- ugcore/ugbase/lib_disc/function_spaces/integrate.h
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
+- ugcore/ugbase/common/util/message_hub.h
+- ugcore/ugbase/pcl/pcl_layout_tests.h

--- a/ugbase/boost_undo.md
+++ b/ugbase/boost_undo.md
@@ -28,57 +28,159 @@ m: Neue Header (MPL).
 
 Weitere Dateiabhängigkeiten von <boost/*>
 
-- ugcore/ugbase/bridge/misc_bridges/test_bridge.cpp: <boost/bind.hpp>
-- ugcore/ugbase/common/util/message_hub.h: <boost/bind.hpp>
-- ugcore/ugbase/common/util/factory.h: 
-    <boost/mpl/for_each.hpp>, 
-    <boost/mpl/vector.hpp>,
+# Resolved
+## Type traits
+- ugcore/ugbase/lib_algebra/operator/interface/constrained_linear_iterator.h: 
+f: <boost/core/enable_if.hpp>, 
+f: <boost/type_traits/is_base_of.hpp>
+- ugcore/ugbase/registry/class.h: 
+f: <boost/type_traits.hpp>, 
+<boost/optional.hpp> => CXX17
+- ugcore/ugbase/registry/registry.h:  
+f: <boost/type_traits.hpp>
+- ugcore/ugbase/common/util/bucket_sorter.hpp: (auskommentiert) 
+f: <boost/limits.hpp>
 
+
+## Bind
+- ugcore/ugbase/bridge/misc_bridges/test_bridge.cpp: 
+o: <boost/bind.hpp>
+- ugcore/ugbase/common/util/message_hub.h: 
+f: <boost/bind.hpp>
+
+# Unresolved
+## Misc
+- ugcore/ugbase/common/util/smart_pointer.h: 
+<boost/pointee.hpp>
+- ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.cpp: 
+<boost/lexical_cast.hpp>
+- ugcore/ugbase/lib_grid/file_io/file_io_swc.cpp: 
+<boost/lexical_cast.hpp>
+- ugcore/ugbase/lib_algebra/common/matrixio/matrix_io_mtx.h: 
+<boost/algorithm/string.hpp>, 
+<boost/lexical_cast.hpp>
+
+## Iterator
+- ugcore/ugbase/lib_algebra/graph_interface/undirected_boost.h: 
+<boost/iterator/counting_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/boost_util.h:
+ <boost/iterator/filter_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/parallel_matrix.h: 
+<boost/iterator/filter_iterator.hpp>
+- ugcore/ugbase/lib_algebra/graph_interface/sparsematrix_boost.h: 
+<boost/iterator/counting_iterator.hpp>
+<boost/graph/properties.hpp> 
+- ugcore/ugbase/lib_algebra/graph_interface/undirected.h: <boost/geometry/iterators/concatenate_iterator.hpp>,
+ <boost/graph/adjacency_list.hpp>
+
+
+## Archive
+- ugcore/ugbase/common/util/base64_file_writer.cpp: 
+ <boost/archive/iterators/transform_width.hpp>,
+ <boost/archive/iterators/base64_from_binary.hpp>,
+ <boost/archive/iterators/ostream_iterator.hpp>
+- ugcore/ugbase/lib_disc/domain_impl.h: 
+<boost/archive/text_oarchive.hpp>, 
+<boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_grid/file_io/file_io_ugx.cpp:
+ <boost/archive/text_oarchive.hpp>,
+  <boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_grid/file_io/file_io_lgb.cpp:
+ <boost/archive/text_oarchive.hpp>,
+  <boost/archive/text_iarchive.hpp>
+- ugcore/ugbase/lib_grid/algorithms/serialization.cpp: (auskommentiert) 
+<boost/archive/text_oarchive.hpp>, 
+<boost/archive/text_iarchive.hpp>
+
+## MPL
+- ugcore/ugbase/common/util/factory.h: 
  f: <boost/static_assert.hpp>
  f: <boost/type_traits/is_base_of.hpp>
+    <boost/mpl/for_each.hpp>, 
+    <boost/mpl/vector.hpp>,
 - ugcore/ugbase/common/util/archivar.h: 
- <boost/mpl/for_each.hpp>, 
-
  f: <boost/static_assert.hpp>,
  f: <boost/type_traits/is_base_of.hpp>
+ <boost/mpl/for_each.hpp>, 
+- ugcore/ugbase/common/util/end_boost_list.h: 
+<boost/mpl/list.hpp>
+- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/err_est_data.h: 
+<boost/mpl/for_each.hpp>
+- ugcore/ugbase/lib_disc/spatial_disc/disc_util/conv_shape.h: 
+<boost/mpl/range_c.hpp>, 
+<boost/mpl/for_each.hpp>
+- ugcore/ugbase/lib_grid/tools/periodic_boundary_manager_impl.hpp: 
+<boost/mpl/map.hpp>, 
+<boost/mpl/at.hpp>
+- ugcore/ugbase/lib_disc/reference_element/element_list_traits.h: 
+<boost/mpl/transform_view.hpp>, 
+<boost/mpl/fold.hpp>,
+ <boost/mpl/min_max.hpp>
+- ugcore/ugbase/bridge/util_algebra_dependent.h: 
+<boost/mpl/if.hpp>, 
+<boost/mpl/list.hpp>, 
+<boost/mpl/empty.hpp>, 
+<boost/mpl/front.hpp>, 
+<boost/mpl/pop_front.hpp>
+- ugcore/ugbase/bridge/util_domain_dependent.h: 
+<boost/mpl/if.hpp>, 
+<boost/mpl/list.hpp>, 
+<boost/mpl/empty.hpp>, 
+<boost/mpl/front.hpp>, 
+<boost/mpl/pop_front.hpp>
+- ugcore/ugbase/lib_grid/grid_objects/grid_dim_traits.h:
+ <boost/mpl/list.hpp>
+- ugcore/ugbase/lib_grid/refinement/projectors/projectors.h: 
+<boost/mpl/pair.hpp>, 
+<boost/mpl/string.hpp>, 
+<boost/mpl/vector.hpp>
+
+## Graph
+- ugcore/ugbase/lib_disc/ordering_strategies/algorithms/riverorder.h: 
+<boost/graph/adjacency_list.hpp>, 
+<boost/graph/graph_traits.hpp>, 
+<boost/graph/properties.hpp>
+- ugcore/ugbase/lib_disc/ordering_strategies/algorithms/directional_ordering.cpp:
+ <boost/graph/adjacency_list.hpp>, 
+ <boost/graph/graph_traits.hpp>, 
+ <boost/graph/properties.hpp>,
+ <boost/graph/cuthill_mckee_ordering.hpp>
+ - ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/topological_ordering.h: 
+<boost/graph/adjacency_list.hpp>, 
+<boost/graph/graph_traits.hpp>, 
+<boost/graph/properties.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/SCC_ordering.h: 
+<boost/graph/adjacency_list.hpp>, 
+<boost/graph/graph_traits.hpp>, 
+<boost/graph/properties.hpp>, 
+<boost/graph/graph_utility.hpp>, 
+<boost/graph/strong_components.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/boost_minimum_degree_ordering.h: 
+<boost/graph/adjacency_list.hpp>, 
+<boost/graph/graph_traits.hpp>, 
+<boost/graph/properties.hpp>, 
+<boost/graph/minimum_degree_ordering.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/boost_cuthill_mckee_ordering.h: 
+<boost/graph/adjacency_list.hpp>,
+ <boost/graph/graph_traits.hpp>, 
+ <boost/graph/properties.hpp>, 
+ <boost/graph/cuthill_mckee_ordering.hpp>
+- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/util.h: 
+<boost/graph/adjacency_list.hpp>, 
+<boost/graph/graph_traits.hpp>
+
+## Serialization
 - ugcore/ugbase/common/util/field.h: 
 <boost/serialization/split_member.hpp>
-- ugcore/ugbase/common/util/base64_file_writer.cpp: <boost/archive/iterators/transform_width.hpp>, <boost/archive/iterators/base64_from_binary.hpp>, <boost/archive/iterators/ostream_iterator.hpp>
-- ugcore/ugbase/common/util/smart_pointer.h: <boost/pointee.hpp>
-- ugcore/ugbase/common/util/bucket_sorter.hpp: (auskommentiert) <boost/limits.hpp>
-- ugcore/ugbase/common/util/end_boost_list.h: <boost/mpl/list.hpp>
-- ugcore/ugbase/common/boost_serialization.h: <boost/serialization/access.hpp>, <boost/serialization/export.hpp>, <boost/serialization/level.hpp>, <boost/serialization/nvp.hpp>, <boost/serialization/version.hpp>
-- ugcore/ugbase/lib_grid/grid_objects/grid_dim_traits.h: <boost/mpl/list.hpp>
-- ugcore/ugbase/lib_grid/refinement/projectors/projectors.h: <boost/mpl/pair.hpp>, <boost/mpl/string.hpp>, <boost/mpl/vector.hpp>
-- ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.h: <boost/serialization/split_member.hpp>
-- ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.cpp: <boost/lexical_cast.hpp>
-- ugcore/ugbase/lib_grid/file_io/file_io_ugx.cpp: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
-- ugcore/ugbase/lib_grid/file_io/file_io_lgb.cpp: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
-- ugcore/ugbase/lib_grid/file_io/file_io_swc.cpp: <boost/lexical_cast.hpp>
-- ugcore/ugbase/lib_grid/algorithms/serialization.cpp: (auskommentiert) <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
-- ugcore/ugbase/lib_grid/tools/periodic_boundary_manager_impl.hpp: <boost/mpl/map.hpp>, <boost/mpl/at.hpp>
-- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/topological_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>
-- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/SCC_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/graph_utility.hpp>, <boost/graph/strong_components.hpp>
-- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/boost_minimum_degree_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/minimum_degree_ordering.hpp>
-- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/boost_cuthill_mckee_ordering.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/cuthill_mckee_ordering.hpp>
-- ugcore/ugbase/lib_algebra/ordering_strategies/algorithms/util.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>
-- ugcore/ugbase/lib_algebra/graph_interface/undirected_boost.h: <boost/iterator/counting_iterator.hpp>
-- ugcore/ugbase/lib_algebra/graph_interface/boost_util.h: <boost/iterator/filter_iterator.hpp>
-- ugcore/ugbase/lib_algebra/graph_interface/parallel_matrix.h: <boost/iterator/filter_iterator.hpp>
-- ugcore/ugbase/lib_algebra/graph_interface/sparsematrix_boost.h: <boost/graph/properties.hpp>, <boost/iterator/counting_iterator.hpp>
-- ugcore/ugbase/lib_algebra/graph_interface/undirected.h: <boost/geometry/iterators/concatenate_iterator.hpp>, <boost/graph/adjacency_list.hpp>
-- ugcore/ugbase/lib_algebra/operator/interface/constrained_linear_iterator.h: <boost/core/enable_if.hpp>, <boost/type_traits/is_base_of.hpp>
-- ugcore/ugbase/lib_algebra/common/matrixio/matrix_io_mtx.h: <boost/algorithm/string.hpp>, <boost/lexical_cast.hpp>
-- ugcore/ugbase/registry/class.h: <boost/type_traits.hpp>, <boost/optional.hpp>
-- ugcore/ugbase/registry/registry.h:  <boost/type_traits.hpp>
-- ugcore/ugbase/lib_disc/spatial_disc/elem_disc/err_est_data.h: <boost/mpl/for_each.hpp>
-- ugcore/ugbase/lib_disc/spatial_disc/disc_util/conv_shape.h: <boost/mpl/range_c.hpp>, <boost/mpl/for_each.hpp>
-- ugcore/ugbase/lib_disc/domain_impl.h: <boost/archive/text_oarchive.hpp>, <boost/archive/text_iarchive.hpp>
-- ugcore/ugbase/lib_disc/reference_element/element_list_traits.h: <boost/mpl/transform_view.hpp>, <boost/mpl/fold.hpp>, <boost/mpl/min_max.hpp>
-- ugcore/ugbase/bridge/util_algebra_dependent.h: <boost/mpl/if.hpp>, <boost/mpl/list.hpp>, <boost/mpl/empty.hpp>, <boost/mpl/front.hpp>, <boost/mpl/pop_front.hpp>
-- ugcore/ugbase/bridge/util_domain_dependent.h: <boost/mpl/if.hpp>, <boost/mpl/list.hpp>, <boost/mpl/empty.hpp>, <boost/mpl/front.hpp>, <boost/mpl/pop_front.hpp>
-- ugcore/ugbase/lib_disc/ordering_strategies/algorithms/riverorder.h: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>
-- ugcore/ugbase/lib_disc/ordering_strategies/algorithms/directional_ordering.cpp: <boost/graph/adjacency_list.hpp>, <boost/graph/graph_traits.hpp>, <boost/graph/properties.hpp>, <boost/graph/cuthill_mckee_ordering.hpp>
+- ugcore/ugbase/common/boost_serialization.h: 
+<boost/serialization/access.hpp>,
+ <boost/serialization/export.hpp>,
+<boost/serialization/level.hpp>, 
+<boost/serialization/nvp.hpp>, 
+<boost/serialization/version.hpp>
+- ugcore/ugbase/lib_grid/refinement/projectors/neurite_projector.h: 
+<boost/serialization/split_member.hpp>
+
 
 Hinweis: Die Liste basiert auf einer Quelltextsuche nach "#include <boost/...>" unter `ugcore/ugbase`. Manche Einträge sind auskommentiert oder mehrfach vorhanden (z.B. Header + generierte Build-Dependency-Dateien). 
 

--- a/ugbase/bridge/disc_bridges/user_data_bridge.cpp
+++ b/ugbase/bridge/disc_bridges/user_data_bridge.cpp
@@ -32,7 +32,6 @@
 
 #include <iostream>
 #include <sstream>
-#include <boost/function.hpp>
 #include <cmath>
 
 // include bridge

--- a/ugbase/bridge/misc_bridges/test_bridge.cpp
+++ b/ugbase/bridge/misc_bridges/test_bridge.cpp
@@ -32,7 +32,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <boost/bind.hpp>
+// #include <functional>
 #include "registry/registry.h"
 #include "bridge/bridge.h"
 #include "bridge/util.h"

--- a/ugbase/common/util/archivar.h
+++ b/ugbase/common/util/archivar.h
@@ -33,9 +33,10 @@
 #ifndef __H__UG_archivar
 #define __H__UG_archivar
 
-#include <boost/static_assert.hpp>
+#include <type_traits> // for std::is_base_of
+
 #include <boost/mpl/for_each.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+
 #include "../boost_serialization.h"
 #include "detail/register_type_pair_functor.h"
 
@@ -47,7 +48,7 @@ namespace archivar{
 	template <typename TArchive, typename TBase, typename TDerived>
 	void CallArchiveOnDerivedClass (TArchive& ar, TBase& base, const char* name)
 	{
-		BOOST_STATIC_ASSERT((boost::is_base_of<TBase, TDerived>::value));
+		static_assert((std::is_base_of<TBase, TDerived>::value), "TDerived is not a subclass of TBase");
 		TDerived& derived = dynamic_cast<TDerived&>(base);
 		ar & make_nvp(name, derived);
 	}
@@ -85,7 +86,7 @@ public:
 	template <class TDerived>
 	void register_class(const char* name)
 	{
-		BOOST_STATIC_ASSERT((boost::is_base_of<TBase, TDerived>::value));
+		static_assert((std::is_base_of<TBase, TDerived>::value), "TDerived is not a subclass of TBase");
 		std::string typeName(typeid(TDerived).name());
 		m_callbackMap[typeName] =
 				&detail::archivar::CallArchiveOnDerivedClass<TArchive, TBase, TDerived>;

--- a/ugbase/common/util/bucket_sorter.hpp
+++ b/ugbase/common/util/bucket_sorter.hpp
@@ -32,7 +32,6 @@
 
 #include <vector>
 #include <cassert>
-//#include <boost/limits.hpp>
 #include "trace.h"
 
 // the __FreeBSD__ condition is a wild guess.

--- a/ugbase/common/util/factory.h
+++ b/ugbase/common/util/factory.h
@@ -33,10 +33,9 @@
 #ifndef __H__UG_factory
 #define __H__UG_factory
 
-#include <boost/static_assert.hpp>
+#include <type_traits> // for std::is_base_of
 #include <boost/mpl/for_each.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/type_traits/is_base_of.hpp>
 #include "../boost_serialization.h"
 #include "detail/register_type_pair_functor.h"
 
@@ -107,7 +106,7 @@ public:
 	void register_class(const char* name)
 	{
 		// UG_LOG("registering derived class: " << className << std::endl);
-		BOOST_STATIC_ASSERT((boost::is_base_of<TBase, TDerived>::value));
+		static_assert((std::is_base_of<TBase, TDerived>::value), "TDerived is not a subclass of TBase");
 
 		std::string className(name);
 

--- a/ugbase/common/util/message_hub.h
+++ b/ugbase/common/util/message_hub.h
@@ -37,9 +37,7 @@
 #include <list>
 #include <string>
 #include <map>
-#include <functional>
-
-#include <boost/bind.hpp>
+#include <functional> // for std::function
 
 #include "common/assert.h"
 #include "common/util/smart_pointer.h"

--- a/ugbase/common/util/message_hub.h
+++ b/ugbase/common/util/message_hub.h
@@ -37,7 +37,7 @@
 #include <list>
 #include <string>
 #include <map>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/function_equal.hpp>
 #include <boost/bind.hpp>
 #include "common/assert.h"
@@ -86,7 +86,7 @@ class MessageHub
 
 	private:
 	//	private type definitions
-		typedef boost::function<void (const IMessage&)> Callback;
+		typedef std::function<void (const IMessage&)> Callback;
 
 	///	The CallbackEntry holds the actual callback and the associated callback-id.
 	/**	If a MessageHub is destroyed before all callbacks are unregistered, this
@@ -226,7 +226,7 @@ class MessageHub
 	 *
 	 * The callback has to be of the type
 	 *
-	 * <tt>boost::function\<void (const IMessage&)\></tt>
+	 * <tt>std::function\<void (const IMessage&)\></tt>
 	 *
 	 * The method returns a smart-pointer to an callback-identifier.
 	 *
@@ -236,7 +236,7 @@ class MessageHub
 	 */
 		template <class TMsg>
 		SPCallbackId register_callback_impl(
-							   boost::function<void (const IMessage&)> callback,
+							   std::function<void (const IMessage&)> callback,
 							   bool autoFree);
 
 	///	performs unregistration of the given callback

--- a/ugbase/common/util/message_hub.h
+++ b/ugbase/common/util/message_hub.h
@@ -38,8 +38,9 @@
 #include <string>
 #include <map>
 #include <functional>
-#include <boost/function_equal.hpp>
+
 #include <boost/bind.hpp>
+
 #include "common/assert.h"
 #include "common/util/smart_pointer.h"
 #include "common/util/metaprogramming_util.h"

--- a/ugbase/common/util/message_hub_impl.hpp
+++ b/ugbase/common/util/message_hub_impl.hpp
@@ -80,7 +80,7 @@ post_message(const TMsg& msg)
 
 template <class TMsg>
 MessageHub::SPCallbackId MessageHub::
-register_callback_impl(boost::function<void (const IMessage&)> callback,
+register_callback_impl(std::function<void (const IMessage&)> callback,
 					   bool autoFree)
 {
 	size_t id = GetUniqueTypeID<TMsg>();

--- a/ugbase/common/util/message_hub_impl.hpp
+++ b/ugbase/common/util/message_hub_impl.hpp
@@ -33,6 +33,8 @@
 #ifndef __H__UG__message_hub_impl__
 #define __H__UG__message_hub_impl__
 
+// #include <boost/bind.hpp> // for boost::bind
+
 namespace ug
 {
 
@@ -57,7 +59,11 @@ register_class_callback(TClass* cls,
 	typedef void (TClass::*ClassCallback)(const IMessage&);
 
 	return register_callback_impl<TMsg>(
-					boost::bind((ClassCallback)callback, cls, _1),
+					//boost::bind((ClassCallback)callback, cls, _1),
+					[callback, cls](const IMessage& msg) {
+        				auto const& derived = static_cast<const TMsg&>(msg);
+						(cls->*callback)(derived);
+    				},
 					autoFree);
 }
 

--- a/ugbase/common/util/smart_pointer.h
+++ b/ugbase/common/util/smart_pointer.h
@@ -35,7 +35,6 @@
 
 #include <functional>
 #include <cstring>
-#include <boost/pointee.hpp>
 
 /// \addtogroup ugbase_common_util
 /// \{
@@ -111,6 +110,7 @@ class SmartPtr
 	friend class ConstSmartPtr<void>;
 
 	public:
+		using element_type = T;
 		explicit SmartPtr() : m_ptr(0), m_refCount(0)	{}
 		explicit SmartPtr(T* ptr) : m_ptr(ptr), m_refCount(0)	{if(ptr) m_refCount = new int(1);}
 		SmartPtr(NullSmartPtr) : m_ptr(0), m_refCount(0)	{}
@@ -297,6 +297,7 @@ class ConstSmartPtr
 	friend class ConstSmartPtr<void>;
 
 	public:
+		using element_type = T;
 		explicit ConstSmartPtr() : m_ptr(0), m_refCount(0)	{}
 		explicit ConstSmartPtr(const T* ptr) : m_ptr(ptr), m_refCount(0)	{if(ptr) m_refCount = new int(1);}
 		ConstSmartPtr(NullSmartPtr) : m_ptr(0), m_refCount(0)	{}
@@ -526,6 +527,7 @@ class SmartPtr<void>
 	friend class ConstSmartPtr<void>;
 
 	public:
+		using element_type = void;
 		explicit SmartPtr() : m_ptr(0), m_refCountPtr(0), m_freeFunc(0) {}
 
 		SmartPtr(NullSmartPtr) : m_ptr(0), m_refCountPtr(0), m_freeFunc(0)	{}
@@ -649,6 +651,7 @@ template <>
 class ConstSmartPtr<void>
 {
 	public:
+		using element_type = void;
 		explicit ConstSmartPtr() : m_ptr(0), m_refCountPtr(0), m_freeFunc(0) {}
 
 		explicit ConstSmartPtr(void* ptr, void (*freeFunc)(const void*)) :
@@ -845,20 +848,9 @@ SmartPtr<T> make_sp(T* inst)
 	return SmartPtr<T>(inst);
 }
 
-namespace boost
-{
-  template <class T>
-  struct pointee<SmartPtr<T> >
-  {
-      typedef T type;
-  };
+// boost::pointee has become deprecated. In C++11, it should be replaced by  
+// std::pointer_traits<my_ptr<T>>::element_type
 
-  template <class T>
-  struct pointee<ConstSmartPtr<T> >
-  {
-      typedef T type;
-  };
-}
 
 // end group ugbase_common_util
 /// \}

--- a/ugbase/lib_algebra/operator/interface/constrained_linear_iterator.h
+++ b/ugbase/lib_algebra/operator/interface/constrained_linear_iterator.h
@@ -39,8 +39,7 @@
 #include "lib_disc/spatial_disc/domain_disc_interface.h"
 #include "preconditioner.h"
 
-#include <boost/core/enable_if.hpp>
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 
 namespace ug {
 
@@ -234,7 +233,7 @@ class ConstrainedLinearIterator : public TLinIt
 
 		// special implementation for IPreconditioner
 		template <typename S>
-		struct apply_update_defect_impl<S, typename boost::enable_if<boost::is_base_of<IPreconditioner<TAlgebra>, S> >::type>
+		struct apply_update_defect_impl<S, typename std::enable_if<std::is_base_of<IPreconditioner<TAlgebra>, S> >::type>
 		{
 			ConstrainedLinearIterator& cli;
 

--- a/ugbase/lib_disc/function_spaces/grid_function_util.h
+++ b/ugbase/lib_disc/function_spaces/grid_function_util.h
@@ -36,7 +36,6 @@
 #include <vector>
 #include <string>
 #include <cmath>  // for isinf, isnan
-#include <boost/function.hpp>
 
 
 #include "common/util/file_util.h"

--- a/ugbase/lib_disc/function_spaces/integrate.h
+++ b/ugbase/lib_disc/function_spaces/integrate.h
@@ -35,7 +35,6 @@
 
 #include <cmath>
 
-#include <boost/function.hpp>
 
 #include "common/common.h"
 

--- a/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
+++ b/ugbase/lib_disc/spatial_disc/elem_disc/dirac_source/lagrange_dirac_source.h
@@ -45,7 +45,6 @@
 #ifndef __H__UG__LIB_DISC__SPACIAL_DISCRETIZATION__ELEM_DISC__DIRAC_SOURCE__LAGRANGE_DIRAC_SOURCE_H__
 #define __H__UG__LIB_DISC__SPACIAL_DISCRETIZATION__ELEM_DISC__DIRAC_SOURCE__LAGRANGE_DIRAC_SOURCE_H__
 
-#include <boost/function.hpp>
 #include <vector>
 #include <string>
 #include <utility>      // std::pair

--- a/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
+++ b/ugbase/lib_disc/spatial_disc/elem_disc/inner_boundary/inner_boundary.h
@@ -42,7 +42,11 @@
 #ifndef __H__UG__LIB_DISC__SPACIAL_DISCRETIZATION__ELEM_DISC__NEUMANN_BOUNDARY__FV1__INNER_BOUNDARY__
 #define __H__UG__LIB_DISC__SPACIAL_DISCRETIZATION__ELEM_DISC__NEUMANN_BOUNDARY__FV1__INNER_BOUNDARY__
 
-#include <boost/function.hpp>
+#include <boost/mpl/empty.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/front.hpp>
+#include <boost/mpl/pop_front.hpp>
+
 #include <vector>
 #include <string>
 #include <utility>      // std::pair

--- a/ugbase/lib_disc/spatial_disc/user_data/data_import.h
+++ b/ugbase/lib_disc/spatial_disc/user_data/data_import.h
@@ -313,7 +313,7 @@ class DataImport : public IDataImport<dim>
 
 	public:
 	///	type of evaluation function
-		typedef boost::function<void (const LocalVector& u,
+		typedef std::function<void (const LocalVector& u,
 		                              std::vector<std::vector<TData> > vvvLinDefect[],
 		                              const size_t nip)> LinDefectFunc;
 

--- a/ugbase/lib_disc/spatial_disc/user_data/data_import_impl.h
+++ b/ugbase/lib_disc/spatial_disc/user_data/data_import_impl.h
@@ -88,7 +88,8 @@ set_fct(ReferenceObjectID id, TClass* obj,
 	if(id >= NUM_REFERENCE_OBJECTS)
 		UG_THROW("Reference Object id invalid: "<<id);
 
-	m_vLinDefectFunc[id] = boost::bind(func, obj, _1, _2, _3);
+	m_vLinDefectFunc[id] = std::bind(func, obj,
+		 std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 }
 
 template <typename TData, int dim>

--- a/ugbase/lib_disc/spatial_disc/user_data/user_data.h
+++ b/ugbase/lib_disc/spatial_disc/user_data/user_data.h
@@ -35,6 +35,7 @@
 
 #include <vector>
 #include <cstring>
+#include <functional>
 
 #include "common/types.h"
 #include "lib_disc/common/local_algebra.h"
@@ -578,7 +579,7 @@ class CplUserData : public ICplUserData<dim>, public UserData<TData,dim,TRet>
 
 	///	registered callbacks
 //		typedef void (DataImport<TData,dim>::*CallbackFct)();
-		typedef boost::function<void ()> CallbackFct;
+		typedef std::function<void ()> CallbackFct;
 		std::vector<std::pair<DataImport<TData,dim>*, CallbackFct> > m_vCallback;
 
 };

--- a/ugbase/lib_disc/spatial_disc/user_data/user_data_impl.h
+++ b/ugbase/lib_disc/spatial_disc/user_data/user_data_impl.h
@@ -274,7 +274,7 @@ register_storage_callback(DataImport<TData,dim>* obj, void (DataImport<TData,dim
 {
 	typedef std::pair<DataImport<TData,dim>*, CallbackFct> Pair;
 	//	m_vCallback.push_back(Pair(obj,func));
-	m_vCallback.push_back(Pair(obj, boost::bind(func, obj)));
+	m_vCallback.push_back(Pair(obj, std::bind(func, obj)));
 }
 
 template <typename TData, int dim, typename TRet>

--- a/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
+++ b/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.cpp
@@ -41,7 +41,6 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include <boost/function.hpp>
 
 #include "lib_grid/algorithms/geom_obj_util/geom_obj_util.h"
 #include "lib_grid/callbacks/callbacks.h"

--- a/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
+++ b/ugbase/lib_grid/algorithms/extrusion/ArteExpandFracs3D.h
@@ -41,7 +41,7 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include <boost/function.hpp>
+
 #include <stack>
 #include <vector>
 #include "lib_grid/lg_base.h"

--- a/ugbase/lib_grid/algorithms/extrusion/DiamondsEstablish3D.h
+++ b/ugbase/lib_grid/algorithms/extrusion/DiamondsEstablish3D.h
@@ -8,7 +8,6 @@
 #ifndef UGCORE_UGBASE_LIB_GRID_ALGORITHMS_EXTRUSION_DIAMONDSESTABLISH3D_H_
 #define UGCORE_UGBASE_LIB_GRID_ALGORITHMS_EXTRUSION_DIAMONDSESTABLISH3D_H_
 
-#include <boost/function.hpp>
 #include <stack>
 #include <vector>
 #include "lib_grid/lg_base.h"

--- a/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
+++ b/ugbase/lib_grid/algorithms/extrusion/expand_layers.cpp
@@ -30,7 +30,7 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include <boost/function.hpp>
+
 #include <stack>
 #include <vector>
 #include "expand_layers.h"

--- a/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
+++ b/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte.cpp
@@ -31,7 +31,6 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include <boost/function.hpp>
 
 #include "expand_layers.h"
 #include "expand_layers_arte.h"

--- a/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
+++ b/ugbase/lib_grid/algorithms/extrusion/expand_layers_arte3D.cpp
@@ -32,7 +32,7 @@
  * GNU Lesser General Public License for more details.
  */
 
-#include <boost/function.hpp>
+
 #include <stack>
 #include <vector>
 #include "lib_grid/lg_base.h"

--- a/ugbase/lib_grid/algorithms/subset_util.h
+++ b/ugbase/lib_grid/algorithms/subset_util.h
@@ -332,7 +332,7 @@ void SeparateSubsetsByLowerDimSelection(Grid& grid, SubsetHandler& sh,
 template <class TElem>
 void SeparateSubsetsByLowerDimSeparators(Grid& grid, SubsetHandler& sh,
 					bool appendAtEnd,
-					boost::function<bool (typename TElem::lower_dim_base_object*)>
+					std::function<bool (typename TElem::lower_dim_base_object*)>
 						cbIsSeparator);
 
 ////////////////////////////////////////////////////////////////////////

--- a/ugbase/lib_grid/algorithms/subset_util_impl.hpp
+++ b/ugbase/lib_grid/algorithms/subset_util_impl.hpp
@@ -112,7 +112,7 @@ void SeparateSubsetsByLowerDimSelection(Grid& grid, SubsetHandler& sh,
 template <class TElem>
 void SeparateSubsetsByLowerDimSeparators(Grid& grid, SubsetHandler& sh,
 					bool appendAtEnd,
-					boost::function<bool (typename TElem::lower_dim_base_object*)>
+					std::function<bool (typename TElem::lower_dim_base_object*)>
 						cbIsSeparator)
 
 {

--- a/ugbase/lib_grid/grid/grid.h
+++ b/ugbase/lib_grid/grid/grid.h
@@ -36,7 +36,7 @@
 #include <vector>
 #include <list>
 #include <memory>
-#include <boost/function.hpp>
+#include <functional>
 #include "common/util/message_hub.h"
 #include "common/ug_config.h"
 #include "grid_constants.h"
@@ -147,7 +147,7 @@ class UG_API Grid
 
 		//	CALLBACKS
 		///	callback type for the elements base type.
-			typedef boost::function<bool (base_object*)>			callback;
+			typedef std::function<bool (base_object*)>			callback;
 		};
 
 	///	Convenience access to grid elements

--- a/ugbase/lib_grid/parallelization/deprecated/load_balancing.cpp
+++ b/ugbase/lib_grid/parallelization/deprecated/load_balancing.cpp
@@ -214,7 +214,7 @@ bool PartitionMultiGrid_MetisKway(SubsetHandler& shPartitionOut,
 template <class TGeomBaseObj>
 bool PartitionMultiGrid_MetisKway(SubsetHandler& shPartitionOut,
 							 	  MultiGrid& mg, int numParts, size_t baseLevel,
-							 	  boost::function<int (TGeomBaseObj*, TGeomBaseObj*)>& weightFct)
+							 	  std::function<int (TGeomBaseObj*, TGeomBaseObj*)>& weightFct)
 {
 #ifdef UG_METIS
 	typedef TGeomBaseObj	TElem;
@@ -695,11 +695,11 @@ template bool PartitionMultiGrid_MetisKway<Volume>(SubsetHandler&, MultiGrid&,
 												   int, size_t, int, int);
 
 template bool PartitionMultiGrid_MetisKway<Edge>(SubsetHandler&, MultiGrid&, int, size_t,
-													 boost::function<int (Edge*, Edge*)>&);
+													 std::function<int (Edge*, Edge*)>&);
 template bool PartitionMultiGrid_MetisKway<Face>(SubsetHandler&, MultiGrid&, int, size_t,
-		 	 	 	 	 	 	 	 	 	 	 boost::function<int (Face*, Face*)>&);
+		 	 	 	 	 	 	 	 	 	 	 std::function<int (Face*, Face*)>&);
 template bool PartitionMultiGrid_MetisKway<Volume>(SubsetHandler&, MultiGrid&, int, size_t,
-												   boost::function<int (Volume*, Volume*)>&);
+												   std::function<int (Volume*, Volume*)>&);
 
 template bool PartitionMultiGridLevel_MetisKway<Edge>(SubsetHandler&,
 													MultiGrid&, int, size_t);

--- a/ugbase/lib_grid/parallelization/deprecated/load_balancing.h
+++ b/ugbase/lib_grid/parallelization/deprecated/load_balancing.h
@@ -123,7 +123,7 @@ bool PartitionMultiGrid_MetisKway(SubsetHandler& shPartitionOut,
 template <class TGeomBaseObj>
 bool PartitionMultiGrid_MetisKway(SubsetHandler& shPartitionOut,
 							 	  MultiGrid& grid, int numParts, size_t baseLevel,
-							 	  boost::function<int (TGeomBaseObj*, TGeomBaseObj*)>& weightFct);
+							 	  std::function<int (TGeomBaseObj*, TGeomBaseObj*)>& weightFct);
 
 ////////////////////////////////////////////////////////////////////////////////
 ///	Partitions the elements in the multi-grid using the METIS library

--- a/ugbase/lib_grid/parallelization/parallelization_util.h
+++ b/ugbase/lib_grid/parallelization/parallelization_util.h
@@ -34,7 +34,7 @@
 #define __H__LIB_GRID__PARALLELIZATION_UTIL__
 
 #include "distributed_grid.h"
-#include <boost/function.hpp>
+
 
 #define PROFILE_GRID_DISTRIBUTION
 #ifdef PROFILE_GRID_DISTRIBUTION

--- a/ugbase/pcl/pcl_layout_tests.h
+++ b/ugbase/pcl/pcl_layout_tests.h
@@ -36,6 +36,7 @@
 #include <vector>
 #include <iomanip> // for 'std::setw()' etc.
 #include <map>
+#include <functional> // std::function()
 
 #include "pcl_base.h"
 #include "pcl_methods.h"
@@ -49,7 +50,6 @@
 #include "common/serialization.h"
 #include "common/profiler/profiler.h"
 
-#include <boost/function.hpp>
 
 namespace pcl
 {
@@ -160,7 +160,7 @@ template<typename TLayout, typename TValue>
 bool TestSizeOfInterfacesInLayoutsMatch(pcl::InterfaceCommunicator<TLayout> &com,
                                         const TLayout &masterLayout,
                                         const TLayout &slaveLayout, bool bPrint=false,
-					boost::function<TValue (typename TLayout::Element)> cbToValue
+					std::function<TValue (typename TLayout::Element)> cbToValue
 						= TrivialToValue<typename TLayout::Element>,
 					bool compareValues = false)
 {
@@ -301,7 +301,7 @@ bool TestLayout(const pcl::ProcessCommunicator &processCommunicator,
                 pcl::InterfaceCommunicator<TLayout> &com,
                 const TLayout &masterLayout,
                 const TLayout &slaveLayout, bool bPrint=false,
-				boost::function<TValue (typename TLayout::Element)> cbToValue
+				std::function<TValue (typename TLayout::Element)> cbToValue
 					= TrivialToValue<typename TLayout::Element>,
 				bool compareValues = false)
 {
@@ -344,7 +344,7 @@ template<typename TLayout, typename TValue>
 bool PrintLayout(const pcl::ProcessCommunicator &processCommunicator,
                  pcl::InterfaceCommunicator<TLayout> &com, const TLayout &masterLayout,
                  const TLayout &slaveLayout,
-                 boost::function<TValue (typename TLayout::Element)> cbToValue
+                 std::function<TValue (typename TLayout::Element)> cbToValue
 					= TrivialToValue<typename TLayout::Element>)
 {
 	return TestLayout(processCommunicator, com, masterLayout, slaveLayout, true, cbToValue);

--- a/ugbase/registry/class.h
+++ b/ugbase/registry/class.h
@@ -37,8 +37,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#include <boost/type_traits.hpp>
-#include <boost/optional.hpp>
+
+#include <type_traits> // for std::is_void
+
+// std::optional is Cxx17 and not yet supported by all compilers, so we use boost::optional for now
+#include <boost/optional.hpp> // for boost::optional
 
 #include "parameter_stack.h"
 #include "function_traits.h"
@@ -842,7 +845,7 @@ class ExportedClass : public ExportedClassBaseImpl
 		                                       std::string options = "")
 		{
 		//	return-type must be void
-			if(!(boost::is_void< typename func_traits<TFunc>::return_type >::value))
+			if(!(std::is_void< typename func_traits<TFunc>::return_type >::value))
 			{
 				UG_THROW_REGISTRY_ERROR(name(),
 				"Trying to register constructor of class "

--- a/ugbase/registry/registry.h
+++ b/ugbase/registry/registry.h
@@ -38,7 +38,7 @@
 #include <cstring>
 #include <typeinfo>
 #include <iostream>
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/type_traits.hpp>
 
 
@@ -68,7 +68,7 @@ class Registry;
  * pass a normal function or a member function of a class
  * (Have a look at boost::bind in the second case).
  */
-typedef boost::function<void (Registry* pReg)> FuncRegistryChanged;
+typedef std::function<void (Registry* pReg)> FuncRegistryChanged;
 
 
 ///	groups classes. One of the members is the default member.

--- a/ugbase/registry/registry.h
+++ b/ugbase/registry/registry.h
@@ -39,8 +39,7 @@
 #include <typeinfo>
 #include <iostream>
 #include <functional>
-#include <boost/type_traits.hpp>
-
+#include <type_traits>
 
 #include "global_function.h"
 #include "class.h"

--- a/ugbase/registry/registry_impl.h
+++ b/ugbase/registry/registry_impl.h
@@ -158,7 +158,7 @@ check_base_class(const std::string& className)
 	}
 
 // 	check that class derives from base class
-	if(boost::is_base_of<TBaseClass, TClass>::value == false)
+	if(std::is_base_of<TBaseClass, TClass>::value == false)
 	{
 		UG_THROW_REGISTRY_ERROR(className,
 		"Trying to register class "<<className


### PR DESCRIPTION
With this correction, we are reducing the dependency on boost:

boost::function => std::function
boost::is_base_of => std::is_base_of
BOOST_STATIC_ASSERT => static_assert.

Removed completely:

#include <boost/function.hpp>
