### PR TITLE
bump cmake version to 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 ################################################
 # ug4

--- a/cmake/ug_cmake_versions.cmake
+++ b/cmake/ug_cmake_versions.cmake
@@ -1,1 +1,1 @@
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)

--- a/ugbase/CMakeLists.txt
+++ b/ugbase/CMakeLists.txt
@@ -32,7 +32,7 @@
 # ugbase
 ################################################
 
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 project(P_UGBASE)
 

--- a/ugbase/bindings/vrl/CMakeLists.txt
+++ b/ugbase/bindings/vrl/CMakeLists.txt
@@ -28,7 +28,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 ####
 # bindings_vrl Library

--- a/ugbase/common/CMakeLists.txt
+++ b/ugbase/common/CMakeLists.txt
@@ -28,7 +28,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 ################################################
 # common

--- a/ugbase/lib_grid/CMakeLists.txt
+++ b/ugbase/lib_grid/CMakeLists.txt
@@ -32,7 +32,7 @@
 # lib_grid
 ################################################
 
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 project(P_LIB_GRID)
 

--- a/ugbase/lib_grid/file_io/externals/src/lgm/CMakeLists.txt
+++ b/ugbase/lib_grid/file_io/externals/src/lgm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 ####
 # liblgm Project

--- a/ugbase/lib_grid/file_io/externals/src/ng/CMakeLists.txt
+++ b/ugbase/lib_grid/file_io/externals/src/ng/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 ####
 # libng Project

--- a/ugbase/pcl/CMakeLists.txt
+++ b/ugbase/pcl/CMakeLists.txt
@@ -32,7 +32,7 @@
 # Parallel Communication Layer
 ################################################
 
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 project(P_PCL)
 

--- a/ugbase/ug_shell/CMakeLists.txt
+++ b/ugbase/ug_shell/CMakeLists.txt
@@ -58,7 +58,7 @@
 ################################################################################
 
 
-cmake_minimum_required(VERSION 2.8.12...3.27.1)
+cmake_minimum_required(VERSION 2.8.12...4.4)
 
 ####
 # ugscript Library


### PR DESCRIPTION
this just bumps the cmake version to 4.4 to fix a
configuration error, with newer cmake.

does not touch the minimum cmake versions